### PR TITLE
fix: add media query listener fallback

### DIFF
--- a/hooks/use-mobile.tsx
+++ b/hooks/use-mobile.tsx
@@ -10,9 +10,22 @@ export function useIsMobile() {
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     }
-    mql.addEventListener("change", onChange)
+    if (typeof mql.addEventListener === "function") {
+      mql.addEventListener("change", onChange)
+    } else {
+      // Safari < 14 support
+      // @ts-ignore - addListener exists on older browsers
+      mql.addListener(onChange)
+    }
     setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
+    return () => {
+      if (typeof mql.removeEventListener === "function") {
+        mql.removeEventListener("change", onChange)
+      } else {
+        // @ts-ignore - removeListener exists on older browsers
+        mql.removeListener(onChange)
+      }
+    }
   }, [])
 
   return !!isMobile


### PR DESCRIPTION
## Summary
- fix `useIsMobile` hook to support browsers without `addEventListener`/`removeEventListener`

## Testing
- `pnpm lint` (fails: How would you like to configure ESLint?)
- `pnpm build` (fails: Failed to fetch Inter from Google Fonts)


------
https://chatgpt.com/codex/tasks/task_e_6897405d430083319cba79848aa2b32b